### PR TITLE
PR: Use `.env` for ports & config across gateway and user-service

### DIFF
--- a/server/skillforge-gateway/src/main/resources/application-dev.yml
+++ b/server/skillforge-gateway/src/main/resources/application-dev.yml
@@ -2,12 +2,17 @@ spring:
   config:
     activate:
       on-profile: dev
+
+server:
+  port: ${SERVER_PORT_GATEWAY:8080}
+  address: "0.0.0.0"
+
 user:
   service:
-    uri: http://localhost:8082
+    uri: http://localhost:${SERVER_PORT_USER}
 course:
   service:
-    uri: http://localhost:8083
+    uri: http://localhost:${SERVER_PORT_COURSES}
 
 gateway:
   cors:

--- a/server/skillforge-gateway/src/main/resources/application-docker.yml
+++ b/server/skillforge-gateway/src/main/resources/application-docker.yml
@@ -3,13 +3,16 @@ spring:
     activate:
       on-profile: docker
 
+server:
+  port: ${SERVER_PORT_GATEWAY:8080}
+  address: "0.0.0.0"
+
 user:
   service:
-    uri: http://user-service:8082
+    uri: http://user-service:${SERVER_PORT_USER}
 course:
   service:
-    uri: http://course-service:8083
-
+    uri: http://course-service:${SERVER_PORT_COURSES}
 
 gateway:
   cors:

--- a/server/skillforge-gateway/src/main/resources/application-test.yml
+++ b/server/skillforge-gateway/src/main/resources/application-test.yml
@@ -2,12 +2,17 @@ spring:
   config:
     activate:
       on-profile: test
+
+server:
+  port: ${SERVER_PORT_GATEWAY:8080}
+  address: "0.0.0.0"
+
 user:
   service:
-    uri: http://user-test:8082
+    uri: http://user-test:${SERVER_PORT_USER}
 course:
   service:
-    uri: http://course-test:8083
+    uri: http://course-test:${SERVER_PORT_COURSES}
 
 gateway:
   cors:

--- a/server/skillforge-gateway/src/main/resources/application.yml
+++ b/server/skillforge-gateway/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8081
+  port: ${SERVER_PORT_GATEWAY:8080}
   address: "0.0.0.0"
 
 spring:

--- a/server/skillforge-user/src/main/resources/application-dev.yml
+++ b/server/skillforge-user/src/main/resources/application-dev.yml
@@ -1,3 +1,8 @@
+server:
+  port: ${SERVER_PORT_USER:8081}
+  address: "0.0.0.0"
+
+
 spring:
   config:
     activate:

--- a/server/skillforge-user/src/main/resources/application-docker.yml
+++ b/server/skillforge-user/src/main/resources/application-docker.yml
@@ -1,3 +1,8 @@
+server:
+  port: ${SERVER_PORT_USER:8081}
+  address: "0.0.0.0"
+
+
 spring:
   config:
     activate:

--- a/server/skillforge-user/src/main/resources/application-prod.yml
+++ b/server/skillforge-user/src/main/resources/application-prod.yml
@@ -1,3 +1,7 @@
+server:
+  port: ${SERVER_PORT_USER:8081}
+  address: "0.0.0.0"
+
 spring:
   config:
     activate:

--- a/server/skillforge-user/src/main/resources/application-test.yml
+++ b/server/skillforge-user/src/main/resources/application-test.yml
@@ -1,3 +1,7 @@
+server:
+  port: ${SERVER_PORT_USER:8081}
+  address: "0.0.0.0"
+
 spring:
   config:
     activate:
@@ -7,5 +11,5 @@ spring:
       database: test-db
 
 jwt:
-  secret: test-secret
-  expirationMs: 3600000
+  secret: ${JWT_SECRET}
+  expirationMs: ${JWT_EXPIRATION_MS}

--- a/server/skillforge-user/src/main/resources/application.yml
+++ b/server/skillforge-user/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8082
+  port: ${SERVER_PORT_USER:8081}
   address: "0.0.0.0"
 
 spring:


### PR DESCRIPTION
#### Why?

Moved hardcoded ports, URIs, and JWT values into `.env` to:

* keep config consistent across local/dev/docker
* reduce duplication and simplify updates
* align with the existing `.env.example` pattern (`SERVER_PORT_GATEWAY`, `SERVER_PORT_USER`, `SERVER_PORT_COURSES`)

#### What changed?

* Replaced hardcoded values with `${...}` in all profiles (with fallback ports)
* Updated `.env` and `.env.example` with needed keys
* Verified with `docker compose up` — gateway & user-service are healthy

> ✅ **Note:** ensure your local `.env` matches `.env.example` values
