### PR TITLE
ci: drop unused author field from create-dotenv action

### DIFF
--- a/.github/actions/create-dotenv/action.yml
+++ b/.github/actions/create-dotenv/action.yml
@@ -1,6 +1,5 @@
 name: "Create Spring .env"
 description: "Generate a .env file with all variables required by Spring services during CI"
-author: "Cascade AI"
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
### Why [.github/actions/create-dotenv/action.yml](cci:7://file:///e:/nosave/TUM/Devops/team-git-it-together/.github/actions/create-dotenv/action.yml:0:0-0:0) exists

* **Purpose** – during CI each Spring-Boot module needs a `.env` file so that
  `${SERVER_PORT_*}`, `JWT_SECRET`, etc. resolve while the tests run.
  Instead of duplicating the same “echo … >> .env” script in every job,
  we wrapped it in a tiny reusable **composite action**.

* **Where it is used**

```yaml
# .github/workflows/build-and-test-server.yml
steps:
  - uses: actions/checkout@v4
  - uses: actions/setup-java@v4
    with:
      java-version: '21'
      distribution: 'temurin'
  - uses: ./.github/actions/create-dotenv   # ← generates .env
  - run: ./gradlew build --no-daemon        # tests read the vars